### PR TITLE
Update pulp call

### DIFF
--- a/src/rota/govuk_2ndline.py
+++ b/src/rota/govuk_2ndline.py
@@ -202,7 +202,7 @@ def generate_model(
 
         prob += obj
 
-    prob.solve(pulp.solvers.COIN_CMD())
+    prob.solve(pulp.COIN_CMD())
 
     if prob.status != pulp.constants.LpStatusOptimal:
         raise NoSatisfyingRotaError()


### PR DESCRIPTION
When I ran this on a fresh install, I got the following stack trace:

```Traceback (most recent call last):
  File "/usr/lib/python3.8/runpy.py", line 193, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.8/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "src/__main__.py", line 87, in <module>
    model = generate_rota(args)
  File "src/__main__.py", line 82, in generate_rota
    return govuk_2ndline_rota.generate_model(people, num_weeks=num_weeks, max_inhours_shifts_per_person=max_inhours_shifts_per_person, max_oncall_shifts_per_person=max_oncall_shifts_per_person,)
  File "src/rota/govuk_2ndline.py", line 205, in generate_model
    prob.solve(pulp.solvers.COIN_CMD())
AttributeError: module 'pulp' has no attribute 'solvers'
```

`COIN_CMD` seems directly callable from pulp, so perhaps we should update that?