### PR TITLE
Use bools, not counts, for eligibility determination

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -11,22 +11,22 @@ Usage:
 
 $ time python3 src demo.csv
 week,primary,secondary,shadow,primary_oncall,secondary_oncall
-1,Annalisa Harrow,Temeka Lowy,,Jerome Silveria,Dave Allred
-2,Renae Paton,Wilson Friesen,,Ryan Averett,Jerold Bayes
-3,Jeannine Demos,Jerald Vangundy,,Dave Allred,Annalisa Harrow
-4,Irwin Capehart,Jarrett Hord,,Lou Meidinger,Jame Truss
-5,Jerome Silveria,Benita Kunz,,Dewey Burgett,Ryan Averett
-6,Deloris Baldon,Emanuel Leinen,,Lou Meidinger,Annalisa Harrow
-7,Dave Allred,Floyd Olsson,,Dewey Burgett,Jeannine Demos
-8,Nyla Drozd,Grant Kornfeld,,Ryan Averett,Annalisa Harrow
-9,Lou Meidinger,Lacy Auyeung,,Dave Allred,Oswaldo Bonham
-10,Martin Ashby,Sammie Shew,Ryan Averett,Jerold Bayes,Jerome Silveria
-11,Theodore Calvery,Robin Hoose,Vernon Minelli,Lou Meidinger,Dewey Burgett
-12,Rocco Morra,Santiago Raine,Pierre Paulhus,Neil Hockenberry,Oswaldo Bonham
+1,Neil Hockenberry,Aubrey Staiger,Sharleen Woltz,Oswaldo Bonham,Jarrett Hord
+2,Deloris Baldon,Rocco Morra,,Martin Ashby,Robin Hoose
+3,Emanuel Leinen,Vernon Minelli,,Lou Meidinger,Renae Paton
+4,Floyd Olsson,Irwin Capehart,,Dewey Burgett,Jerold Bayes
+5,Pierre Paulhus,Sammie Shew,,Lou Meidinger,Wilson Friesen
+6,Jerome Silveria,Benita Kunz,Glynda Laubscher,Oswaldo Bonham,Temeka Lowy
+7,Jame Truss,Nyla Drozd,,Annalisa Harrow,Renae Paton
+8,Ryan Averett,Jerald Vangundy,,Jeannine Demos,Jerold Bayes
+9,Theodore Calvery,Temeka Lowy,Chas Stucky,Dave Allred,Grant Kornfeld
+10,Martin Ashby,Lacy Auyeung,Ramon Haddock,Annalisa Harrow,Oswaldo Bonham
+11,Bessie Engebretson,Wilson Friesen,,Jeannine Demos,Jerold Bayes
+12,Dave Allred,Lou Meidinger,,Annalisa Harrow,Santiago Raine
 
-real    33.38s
-user    32.99s
-sys     0.36s
+real    0m24.531s
+user    0m24.408s
+sys     0m0.121s
 ```
 
 See the `docs` directory for explanations of how the rotas are defined

--- a/demo.csv
+++ b/demo.csv
@@ -1,40 +1,40 @@
-name,team,can_do_inhours,num_times_inhours,num_times_shadow,can_do_oncall,num_times_oncall,forbidden_weeks
-Oswaldo Bonham,Platform Health,yes,3,3,yes,3,
-Jame Truss,Platform Health,yes,3,3,yes,3,
-Jarrett Hord,Platform Health ,yes,0,3,no,0,
-Neil Hockenberry,Platform Health,yes,3,3,yes,3,
-Grant Kornfeld,Platform Health,yes,0,3,no,0,
-Bessie Engebretson,Platform Health,yes,3,3,no,0,
-Emanuel Leinen,Platform Health ,yes,2,3,no,0,
-Sammie Shew,Platform Health,yes,1,3,no,0,
-Renae Paton,Platform Health,yes,3,3,no,0,"4,5,6"
-Santiago Raine,Platform Health,yes,2,3,no,0,
-Chas Stucky,Platform Health,no,0,1,no,0,
-Ryan Averett,Publishing Access and Security,yes,3,2,yes,3,
-Martin Ashby,FE Dev and Accessibility,yes,3,3,yes,3,"1,3,4,5,6,7,8"
-Deloris Baldon,FE Dev and Accessibility,yes,3,3,no,0,
-Nyla Drozd,FE Dev and Accessibility,yes,3,3,no,0,"1,2"
-Pierre Paulhus,FE Dev and Accessibility,yes,0,0,no,0,
-Jerome Silveria,Search,yes,3,3,yes,3,
-Wilson Friesen,Structured data,yes,2,3,no,0,
-Robin Hoose,Search,yes,2,3,no,0,
-Floyd Olsson,Search,yes,3,3,no,0,
-Lou Meidinger,Search,yes,3,3,yes,1,"1,2"
+name,team,can_do_inhours_primary,can_do_inhours_secondary,can_do_inhours_shadow,can_do_oncall_primary,can_do_oncall_secondary,forbidden_weeks
+Oswaldo Bonham,Platform Health,yes,yes,no,yes,yes,
+Jame Truss,Platform Health,yes,yes,no,yes,yes,
+Jarrett Hord,Platform Health,yes,yes,no,no,yes,
+Neil Hockenberry,Platform Health,yes,yes,no,yes,yes,
+Grant Kornfeld,Platform Health,yes,yes,no,no,yes,
+Bessie Engebretson,Platform Health,yes,yes,no,no,no,
+Emanuel Leinen,Platform Health ,yes,yes,no,no,no,
+Sammie Shew,Platform Health,yes,yes,no,no,yes,
+Renae Paton,Platform Health,yes,yes,no,no,yes,"4,5,6"
+Santiago Raine,Platform Health,yes,yes,no,no,yes,
+Chas Stucky,Platform Health,no,no,yes,no,no,
+Ryan Averett,Publishing Access and Security,yes,yes,no,yes,yes,
+Martin Ashby,FE Dev and Accessibility,yes,yes,no,yes,yes,"1,3,4,5,6,7,8"
+Deloris Baldon,FE Dev and Accessibility,yes,yes,no,no,no,
+Nyla Drozd,FE Dev and Accessibility,yes,yes,no,no,no,"1,2"
+Pierre Paulhus,FE Dev and Accessibility,yes,yes,no,no,no,
+Jerome Silveria,Search,yes,yes,no,yes,yes,
+Wilson Friesen,Structured data,yes,yes,no,no,yes,
+Robin Hoose,Search,yes,yes,no,no,yes,
+Floyd Olsson,Search,yes,yes,no,no,yes,
+Lou Meidinger,Search,yes,yes,no,yes,1,"1,2"
 Sharleen Woltz,Search,no,0,1,no,0,
 Ramon Haddock,Search,no,0,1,no,0,
-Jerald Vangundy,Search,yes,2,3,no,0,
-Theodore Calvery,Taxonomy,yes,3,3,no,0,
-Dewey Burgett,Publisher Workflow,yes,3,3,yes,3,
-Irwin Capehart,Publisher Workflow,yes,3,3,no,0,
-Jerold Bayes,Publisher Workflow,yes,3,3,yes,3,"5,6,7,12"
-Annalisa Harrow,Publisher Workflow,yes,3,3,yes,3,
-Dave Allred,Publisher Workflow,yes,3,3,yes,3,
-Rocco Morra,Publisher Workflow,yes,3,3,no,0,
-Eddie Mccollough,Publisher Workflow,no,0,0,no,0,
-Lacy Auyeung,Publisher Workflow,yes,2,3,no,0,
-Glynda Laubscher,Publisher Workflow,no,0,1,no,0,"1,8,10,11,12"
-Jeannine Demos,Step by step,yes,3,3,yes,3,"1,2"
-Vernon Minelli,Step by step,yes,0,1,no,0,
-Temeka Lowy,Step by step,yes,0,3,no,0,
-Benita Kunz,Step by step,yes,0,3,no,0,
-Aubrey Staiger,Personalisation and programme,no,3,3,no,3,
+Jerald Vangundy,Search,yes,yes,no,no,0,
+Theodore Calvery,Taxonomy,yes,yes,no,no,0,
+Dewey Burgett,Publisher Workflow,yes,yes,no,yes,yes,
+Irwin Capehart,Publisher Workflow,yes,yes,no,no,yes,
+Jerold Bayes,Publisher Workflow,yes,yes,no,yes,yes,"5,6,7,12"
+Annalisa Harrow,Publisher Workflow,yes,yes,no,yes,yes,
+Dave Allred,Publisher Workflow,yes,yes,no,yes,yes,
+Rocco Morra,Publisher Workflow,yes,yes,no,no,no,
+Eddie Mccollough,Publisher Workflow,no,0,0,no,no,
+Lacy Auyeung,Publisher Workflow,yes,yes,no,no,yes,
+Glynda Laubscher,Publisher Workflow,no,no,yes,no,no,"1,8,10,11,12"
+Jeannine Demos,Step by step,yes,yes,no,yes,yes,"1,2"
+Vernon Minelli,Step by step,yes,yes,no,no,no,
+Temeka Lowy,Step by step,yes,yes,no,no,yes,
+Benita Kunz,Step by step,yes,yes,no,no,no,
+Aubrey Staiger,Personalisation and programme,no,yes,no,no,no,

--- a/docs/govuk_2ndline.md
+++ b/docs/govuk_2ndline.md
@@ -19,70 +19,66 @@ Parameters
 
 *Internal parameters:*
 
-| Name                         | Default | Description                                                        |
-|:---------------------------- | -------:|:------------------------------------------------------------------ |
-| `times_inhours_for_primary`  |       3 | Number of in-hours shifts someone must have done to be a primary.  |
-| `times_shadow_for_secondary` |       3 | Number of shadow shifts someone must have done to be a secondary.  |
-| `times_oncall_for_secondary` |       3 | Number of on-call shifts someone must have done to be a secondary. |
-| `max_times_shadow`           |       3 | Maximum number of times someone can shadow.                        |
-| `optimise`                   |  `true` | Whether optimise for the objective functions.                      |
+| Name        | Default | Description                                   |
+|:------------| -------:|:--------------------------------------------- |
+| `optimise`  |  `true` | Whether optimise for the objective functions. |
 
 
 Input format
 ------------
 
 - `name`: string (must be unique)
-- `team`: string (compared stripped and lowercased)
-- `can_do_inhours`: bool
-- `num_times_inhours`: integer, the number of in-hours non-shadow shifts up to the start of the rota period
-- `num_times_shadow`: integer, the number of in-hours shadow shifts up to the start of the rota period
-- `can_do_oncall`: bool
-- `num_times_oncall`: integer, the number of on-call shifts up to the start of the rota period
+- `team`: string (compared stripped and lowercased)-
+- `can_do_inhours_primary`: bool
+- `can_do_inhours_secondary`: bool
+- `can_do_inhours_shadow`: bool
+- `can_do_oncall_primary`: bool
+- `can_do_oncall_secondary`: bool
 - `forbidden_weeks`: integer comma-separated list, weeks unavailable (week 1 = first week of the generated rota)
 
 *Example:*
 
 ```csv
-name,team,can_do_inhours,num_times_inhours,num_times_shadow,can_do_oncall,num_times_oncall,forbidden_weeks
-Oswaldo Bonham,Platform Health,yes,3,2,yes,3,
-Jame Truss,Platform Health,yes,3,2,yes,3,
-Jarrett Hord,Platform Health ,yes,0,2,no,0,
-Neil Hockenberry,Platform Health,yes,3,2,yes,3,
-Grant Kornfeld,Platform Health,yes,0,2,no,0,
-Bessie Engebretson,Platform Health,yes,3,2,no,0,
-Emanuel Leinen,Platform Health ,yes,2,2,no,0,
-Sammie Shew,Platform Health,yes,1,2,no,0,
-Renae Paton,Platform Health,yes,3,2,no,0,"4,5,6"
-Santiago Raine,Platform Health,yes,2,2,no,0,
-Chas Stucky,Platform Health,no,0,1,no,0,
-Ryan Averett,Publishing Access and Security,yes,3,2,yes,3,
-Martin Ashby,FE Dev and Accessibility,yes,3,2,yes,3,"1,3,4,5,6,7,8"
-Deloris Baldon,FE Dev and Accessibility,yes,3,2,no,0,
-Nyla Drozd,FE Dev and Accessibility,yes,3,2,no,0,"1,2"
-Pierre Paulhus,FE Dev and Accessibility,yes,0,0,no,0,
-Jerome Silveria,Search,yes,3,2,yes,3,
-Wilson Friesen,Structured data,yes,2,2,no,0,
-Robin Hoose,Search,yes,2,2,no,0,
-Floyd Olsson,Search,yes,3,2,no,0,
-Lou Meidinger,Search,yes,3,2,yes,1,"1,2"
+name,team,can_do_inhours_primary,can_do_inhours_secondary,can_do_inhours_shadow,can_do_oncall_primary,can_do_oncall_secondary,forbidden_weeks
+Oswaldo Bonham,Platform Health,yes,yes,no,yes,yes,
+Jame Truss,Platform Health,yes,yes,no,yes,yes,
+Jarrett Hord,Platform Health,yes,yes,no,no,yes,
+Neil Hockenberry,Platform Health,yes,yes,no,yes,yes,
+Grant Kornfeld,Platform Health,yes,yes,no,no,yes,
+Bessie Engebretson,Platform Health,yes,yes,no,no,no,
+Emanuel Leinen,Platform Health ,yes,yes,no,no,no,
+Sammie Shew,Platform Health,yes,yes,no,no,yes,
+Renae Paton,Platform Health,yes,yes,no,no,yes,"4,5,6"
+Santiago Raine,Platform Health,yes,yes,no,no,yes,
+Chas Stucky,Platform Health,no,no,yes,no,no,
+Ryan Averett,Publishing Access and Security,yes,yes,no,yes,yes,
+Martin Ashby,FE Dev and Accessibility,yes,yes,no,yes,yes,"1,3,4,5,6,7,8"
+Deloris Baldon,FE Dev and Accessibility,yes,yes,no,no,no,
+Nyla Drozd,FE Dev and Accessibility,yes,yes,no,no,no,"1,2"
+Pierre Paulhus,FE Dev and Accessibility,yes,yes,no,no,no,
+Jerome Silveria,Search,yes,yes,no,yes,yes,
+Wilson Friesen,Structured data,yes,yes,no,no,yes,
+Robin Hoose,Search,yes,yes,no,no,yes,
+Floyd Olsson,Search,yes,yes,no,no,yes,
+Lou Meidinger,Search,yes,yes,no,yes,1,"1,2"
 Sharleen Woltz,Search,no,0,1,no,0,
 Ramon Haddock,Search,no,0,1,no,0,
-Jerald Vangundy,Search,yes,2,2,no,0,
-Theodore Calvery,Taxonomy,yes,3,2,no,0,
-Dewey Burgett,Publisher Workflow,yes,3,2,yes,3,
-Irwin Capehart,Publisher Workflow,yes,3,2,no,0,
-Jerold Bayes,Publisher Workflow,yes,3,2,yes,3,"5,6,7,12"
-Annalisa Harrow,Publisher Workflow,yes,3,2,yes,3,
-Dave Allred,Publisher Workflow,yes,3,2,yes,3,
-Rocco Morra,Publisher Workflow,yes,3,2,no,0,
-Eddie Mccollough,Publisher Workflow,no,0,0,no,0,
-Lacy Auyeung,Publisher Workflow,yes,2,2,no,0,
-Glynda Laubscher,Publisher Workflow,no,0,1,no,0,"1,8,10,11,12"
-Jeannine Demos,Step by step,yes,3,2,yes,3,"1,2"
-Vernon Minelli,Step by step,yes,0,1,no,0,
-Temeka Lowy,Step by step,yes,0,2,no,0,
-Benita Kunz,Step by step,yes,0,2,no,0,
-Aubrey Staiger,Personalisation and programme,no,3,2,no,3,
+Jerald Vangundy,Search,yes,yes,no,no,0,
+Theodore Calvery,Taxonomy,yes,yes,no,no,0,
+Dewey Burgett,Publisher Workflow,yes,yes,no,yes,yes,
+Irwin Capehart,Publisher Workflow,yes,yes,no,no,yes,
+Jerold Bayes,Publisher Workflow,yes,yes,no,yes,yes,"5,6,7,12"
+Annalisa Harrow,Publisher Workflow,yes,yes,no,yes,yes,
+Dave Allred,Publisher Workflow,yes,yes,no,yes,yes,
+Rocco Morra,Publisher Workflow,yes,yes,no,no,no,
+Eddie Mccollough,Publisher Workflow,no,0,0,no,no,
+Lacy Auyeung,Publisher Workflow,yes,yes,no,no,yes,
+Glynda Laubscher,Publisher Workflow,no,no,yes,no,no,"1,8,10,11,12"
+Jeannine Demos,Step by step,yes,yes,no,yes,yes,"1,2"
+Vernon Minelli,Step by step,yes,yes,no,no,no,
+Temeka Lowy,Step by step,yes,yes,no,no,yes,
+Benita Kunz,Step by step,yes,yes,no,no,no,
+Aubrey Staiger,Personalisation and programme,no,yes,no,no,no,
 ```
 
 
@@ -90,35 +86,20 @@ Constraints
 -----------
 
 1. [Standard rota constraints](rota.md#standard-constraints)
-2. In every week:
-   1. **Primary** must:
-      1. be able to do in-hours support
-      2. have been on in-hours support at least `times_inhours_for_primary` times (not including earlier instances in this rota)
-   2. **Secondary** must:
-      1. be able to do in-hours support
-      2. have shadowed at least `times_shadow_for_secondary` times (not including earlier instances in this rota)
-   3. **Shadow** must:
-      1. be able to do in-hours support
-      2. have shadowed at most `max_times_shadow` times before (not including earlier instances in this rota)
-   4. **Primary oncall** must be able to do out-of-hours support
-   5. **Secondary oncall** must:
-      1. be able to do out-of-hours support
-      2. have done out-of-hours support at least `times_oncall_for_secondary` times (not including earlier instances in this rota)
-3. A person must:
-   1. not be assigned roles in two adjacent weeks
-   2. not be assigned more than `max-in-hours-shifts` in-hours roles in total
-   3. not be assigned more than `max-on-call-shifts` out-of-hours roles in total
-   4. not be on in-hours support in the same week that someone else from their team is also on in-hours support
-   5. not be on in-hours support in the week after someone else from their team is also on in-hours support
+2. A person must:
+   1. not be assigned a role they can't take
+   2. not be assigned roles in two adjacent weeks
+   3. not be assigned more than `max-in-hours-shifts` in-hours roles in total
+   4. not be assigned more than `max-on-call-shifts` out-of-hours roles in total
+   5. not be on in-hours support in the same week that someone else from their team is also on in-hours support
+   6. not be on in-hours support in the week after someone else from their team is also on in-hours support
 
 
 Objectives
 ----------
 
 1. *Maximise* the number of people with assignments.
-2. *Maximise* the number of weeks where **secondary** has been on in-hours support fewer than `times_inhours_for_primary` times.
-3. *Maximise* the number of weeks where **primary oncall** has been on out-of-hours support fewer than `times_oncall_for_secondary` times.
-4. *Maximise* the number of weeks with a **shadow**.
+2. *Maximise* the number of weeks with a **shadow**.
 
 *Commentary:*
 

--- a/docs/govuk_2ndline.md
+++ b/docs/govuk_2ndline.md
@@ -94,7 +94,6 @@ Constraints
    1. **Primary** must:
       1. be able to do in-hours support
       2. have been on in-hours support at least `times_inhours_for_primary` times (not including earlier instances in this rota)
-      3. be at least as experienced as **secondary**
    2. **Secondary** must:
       1. be able to do in-hours support
       2. have shadowed at least `times_shadow_for_secondary` times (not including earlier instances in this rota)
@@ -105,21 +104,12 @@ Constraints
    5. **Secondary oncall** must:
       1. be able to do out-of-hours support
       2. have done out-of-hours support at least `times_oncall_for_secondary` times (not including earlier instances in this rota)
-      3. be at least as experienced as **primary**
 3. A person must:
    1. not be assigned roles in two adjacent weeks
    2. not be assigned more than `max-in-hours-shifts` in-hours roles in total
    3. not be assigned more than `max-on-call-shifts` out-of-hours roles in total
    4. not be on in-hours support in the same week that someone else from their team is also on in-hours support
    5. not be on in-hours support in the week after someone else from their team is also on in-hours support
-
-*Commentary:*
-
-There's an asymmetry: the **primary** is required to be more
-experienced than the **secondary**, but the opposite is the case for
-on-call roles.  This is intentional!  If the **primary oncall** were
-more experienced, they would resolve every issue themselves and the
-less experienced one would never get to learn anything.
 
 
 Objectives

--- a/docs/govuk_2ndline.md
+++ b/docs/govuk_2ndline.md
@@ -93,18 +93,18 @@ Constraints
 2. In every week:
    1. **Primary** must:
       1. be able to do in-hours support
-      2. have been on in-hours support at least `times_inhours_for_primary` times (including earlier instances in this rota)
+      2. have been on in-hours support at least `times_inhours_for_primary` times (not including earlier instances in this rota)
       3. be at least as experienced as **secondary**
    2. **Secondary** must:
       1. be able to do in-hours support
-      2. have shadowed at least `times_shadow_for_secondary` times (including earlier instances in this rota)
+      2. have shadowed at least `times_shadow_for_secondary` times (not including earlier instances in this rota)
    3. **Shadow** must:
       1. be able to do in-hours support
-      2. have shadowed at most `max_times_shadow` times before (including earlier instances in this rota)
+      2. have shadowed at most `max_times_shadow` times before (not including earlier instances in this rota)
    4. **Primary oncall** must be able to do out-of-hours support
    5. **Secondary oncall** must:
       1. be able to do out-of-hours support
-      2. have done out-of-hours support at least `times_oncall_for_secondary` times (including earlier instances in this rota)
+      2. have done out-of-hours support at least `times_oncall_for_secondary` times (not including earlier instances in this rota)
       3. be at least as experienced as **primary**
 3. A person must:
    1. not be assigned roles in two adjacent weeks

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -40,7 +40,6 @@ def print_rota_csv(rota):
                 if rota.is_assigned(period, person, role):
                     r[role.name.lower()] = person
 
-        rota.post_process(r)
         writer.writerow(r)
 
 

--- a/src/parser.py
+++ b/src/parser.py
@@ -9,7 +9,7 @@ class CSVException(Exception):
         self.errors = errors
 
 
-def to_bool(s, lenient=False):
+def to_bool(s):
     """A stricter boolification function than 'bool'."""
 
     true_strings = ["true", "yes", "y", "1"]
@@ -17,7 +17,7 @@ def to_bool(s, lenient=False):
 
     if s.lower() in true_strings:
         return True
-    if lenient or s.lower() in false_strings:
+    if s.lower() in false_strings:
         return False
 
     raise ValueError(f"String '{s} not in {true_strings} or {false_strings}")
@@ -34,37 +34,37 @@ def govuk_2ndline(rn, row):
 
     person = row[0].strip()
     team = row[1].lower().strip()
-    can_do_inhours_str = row[2].strip()
-    num_times_inhours_str = row[3].strip()
-    num_times_shadow_str = row[4].strip()
-    can_do_oncall_str = row[5].strip()
-    num_times_oncall_str = row[6].strip()
+    can_do_inhours_primary_str = row[2].strip()
+    can_do_inhours_secondary_str = row[3].strip()
+    can_do_inhours_shadow_str = row[4].strip()
+    can_do_oncall_primary_str = row[5].strip()
+    can_do_oncall_secondary_str = row[6].strip()
     forbidden_weeks_str = row[7].strip()
 
     try:
-        can_do_inhours = to_bool(can_do_inhours_str)
+        can_do_inhours_primary = to_bool(can_do_inhours_primary_str)
     except ValueError:
-        errors.append(f"Row {rn}: 'can_do_inhours' field should be a boolean (got '{can_do_inhours_str}')")
+        errors.append(f"Row {rn}: 'can_do_inhours_primary' field should be a boolean (got '{can_do_inhours_primary_str}')")
 
     try:
-        num_times_inhours = int(num_times_inhours_str)
+        can_do_inhours_secondary = to_bool(can_do_inhours_secondary_str)
     except ValueError:
-        errors.append(f"Row {rn}: 'num_times_inhours' field should be an integer (got '{num_times_inhours_str}')")
+        errors.append(f"Row {rn}: 'can_do_inhours_secondary' field should be a boolean (got '{can_do_inhours_secondary_str}')")
 
     try:
-        num_times_shadow = int(num_times_shadow_str)
+        can_do_inhours_shadow = to_bool(can_do_inhours_shadow_str)
     except ValueError:
-        errors.append(f"Row {rn}: 'num_times_shadow' field should be an integer (got '{num_times_shadow_str}')")
+        errors.append(f"Row {rn}: 'can_do_inhours_shadow' field should be a boolean (got '{can_do_inhours_shadow_str}')")
 
     try:
-        can_do_oncall = to_bool(can_do_oncall_str)
+        can_do_oncall_primary = to_bool(can_do_oncall_primary_str)
     except ValueError:
-        errors.append(f"Row {rn}: 'can_do_oncall' field should be a boolean (got '{can_do_oncall_str}')")
+        errors.append(f"Row {rn}: 'can_do_oncall_primary' field should be a boolean (got '{can_do_oncall_primary_str}')")
 
     try:
-        num_times_oncall = int(num_times_oncall_str)
+        can_do_oncall_secondary = to_bool(can_do_oncall_secondary_str)
     except ValueError:
-        errors.append(f"Row {rn}: 'num_times_oncall' field should be an integer (got '{num_times_oncall_str}')")
+        errors.append(f"Row {rn}: 'can_do_oncall_secondary' field should be a boolean (got '{can_do_oncall_secondary_str}')")
 
     try:
         forbidden_weeks = [int(n) - 1 for n in forbidden_weeks_str.split(",") if n != ""]
@@ -77,11 +77,11 @@ def govuk_2ndline(rn, row):
     return {
         person: govuk_2ndline_rota.Person(
             team=team,
-            can_do_inhours=can_do_inhours,
-            num_times_inhours=num_times_inhours,
-            num_times_shadow=num_times_shadow,
-            can_do_oncall=can_do_oncall,
-            num_times_oncall=num_times_oncall,
+            can_do_inhours_primary=can_do_inhours_primary,
+            can_do_inhours_secondary=can_do_inhours_secondary,
+            can_do_inhours_shadow=can_do_inhours_shadow,
+            can_do_oncall_primary=can_do_oncall_primary,
+            can_do_oncall_secondary=can_do_oncall_secondary,
             forbidden_weeks=forbidden_weeks,
         )
     }

--- a/src/rota/__init__.py
+++ b/src/rota/__init__.py
@@ -29,22 +29,6 @@ class Rota:
         pass
 
 
-def if_then(prob, var_a, k, var_b, var_d):
-    """Translate 'if var_a > k then var_b >= 0 else var_b = 0' into ILP constraints.
-
-    'var_d' must be a fresh decision variable.
-
-    See http://www.yzuda.org/Useful_Links/optimization/if-then-else-02.html
-    """
-
-    # a number bigger than the number of times someone can actually be on shift
-    m = 999
-
-    prob += var_a - k + m * var_d >= 1
-    prob += var_b + m * var_d >= 0
-    prob += var_a - k <= 0 + m * (1 - var_d)
-    prob += var_b <= m * (1 - var_d)
-
 
 def basic_rota(title, num_periods, person_names, role_names, optional_roles=[], personal_leave={}, sense=pulp.LpMaximize, randomise=True):
     """Generate a basic rota problem that ensures:

--- a/src/rota/__init__.py
+++ b/src/rota/__init__.py
@@ -20,15 +20,6 @@ class Rota:
 
         raise NotImplementedError()
 
-    def post_process(self, assignments):
-        """Transform a single period's assignments.
-
-        Mutates the parameter.
-        """
-
-        pass
-
-
 
 def basic_rota(title, num_periods, person_names, role_names, optional_roles=[], personal_leave={}, sense=pulp.LpMaximize, randomise=True):
     """Generate a basic rota problem that ensures:

--- a/src/rota/govuk_2ndline.py
+++ b/src/rota/govuk_2ndline.py
@@ -7,7 +7,9 @@ from rota import Rota, basic_rota, NoSatisfyingRotaError
 
 # A person who can appear in the rota.  People have no names, as
 # 'generate_model' is given a dict 'name -> person'.
-Person = collections.namedtuple("Person", ["team", "can_do_inhours", "num_times_inhours", "num_times_shadow", "can_do_oncall", "num_times_oncall", "forbidden_weeks"])
+Person = collections.namedtuple(
+    "Person", ["team", "can_do_inhours_primary", "can_do_inhours_secondary", "can_do_inhours_shadow", "can_do_oncall_primary", "can_do_oncall_secondary", "forbidden_weeks"]
+)
 
 # A role
 Role = collections.namedtuple("Role", ["n", "inhours", "oncall", "mandatory"])
@@ -39,10 +41,6 @@ def generate_model(
     num_weeks=2,
     max_inhours_shifts_per_person=1,
     max_oncall_shifts_per_person=3,
-    times_inhours_for_primary=3,
-    times_shadow_for_secondary=3,
-    times_oncall_for_secondary=3,
-    max_times_shadow=3,
     optimise=True,
 ):
     """Generate the mathematical model of the rota problem."""
@@ -58,52 +56,34 @@ def generate_model(
 
     # ## Constraints
 
-    # In every week:
-    for week in range(num_weeks):
-        # [2.1.1] Primary must: be able to do in-hours support
-        # [2.2.1] Secondary must: be able to do in-hours support
-        # [2.3.1] Shadow must: be able to do in-hours support
-        # [2.4]   Primary oncall must: be able to do out-of-hours support
-        # [2.5.1] Secondary oncall must: be able to do out-of-hours support
-        for person, p in people.items():
-            for role in Roles:
-                if role.value.inhours and not p.can_do_inhours:
-                    prob += rota[week, person, role.name] == 0
-                if role.value.oncall and not p.can_do_oncall:
-                    prob += rota[week, person, role.name] == 0
-
-        # [2.1.2] Primary must: have been on in-hours support at least `times_inhours_for_primary` times
-        # [2.2.2] Secondary must: have shadowed at least `times_shadow_for_secondary` times
-        # [2.5.2] Secondary oncall must: have done out-of-hours support at least `times_oncall_for_secondary` times
-        for person, p in people.items():
-            if p.num_times_inhours < times_inhours_for_primary:
-                prob += rota[week, person, Roles.PRIMARY.name] == 0
-            if p.num_times_shadow < times_shadow_for_secondary:
-                prob += rota[week, person, Roles.SECONDARY.name] == 0
-            if p.num_times_oncall < times_oncall_for_secondary:
-                prob += rota[week, person, Roles.SECONDARY_ONCALL.name] == 0
-
     # A person must:
     for person, p in people.items():
-        # [2.4.2] Not shadow more than `max_times_shadow` times
-        if p.num_times_shadow >= max_times_shadow:
-            prob += pulp.lpSum(rota[week, person, Roles.SHADOW.name] for week in range(num_weeks)) == 0
-        else:
-            prob += p.num_times_shadow + pulp.lpSum(rota[week, person, Roles.SHADOW.name] for week in range(num_weeks)) <= max_times_shadow
+        # [2.1] Not be assigned a role they can't take
+        for week in range(num_weeks):
+            if not p.can_do_inhours_primary:
+                prob += rota[week, person, Roles.PRIMARY.name] == 0
+            if not p.can_do_inhours_secondary:
+                prob += rota[week, person, Roles.SECONDARY.name] == 0
+            if not p.can_do_inhours_shadow:
+                prob += rota[week, person, Roles.SHADOW.name] == 0
+            if not p.can_do_oncall_primary:
+                prob += rota[week, person, Roles.PRIMARY_ONCALL.name] == 0
+            if not p.can_do_oncall_secondary:
+                prob += rota[week, person, Roles.SECONDARY_ONCALL.name] == 0
 
-        # [3.1] Not be assigned roles in two adjacent weeks
+        # [2.2] Not be assigned roles in two adjacent weeks
         for week in range(num_weeks):
             if week != 0:
                 prob += pulp.lpSum(rota[week, person, role.name] for role in Roles) + pulp.lpSum(rota[week - 1, person, role.name] for role in Roles) <= 1
 
-        # [3.2] Not be assigned more than `max_inhours_shifts_per_person` in-hours roles in total
+        # [2.3] Not be assigned more than `max_inhours_shifts_per_person` in-hours roles in total
         prob += pulp.lpSum(rota[week, person, role.name] for week in range(num_weeks) for role in Roles if role.value.inhours) <= max_inhours_shifts_per_person
 
-        # [3.3] Not be assigned more than `max_oncall_shifts_per_person` out-of-hours roles in total
+        # [2.4] Not be assigned more than `max_oncall_shifts_per_person` out-of-hours roles in total
         prob += pulp.lpSum(rota[week, person, role.name] for week in range(num_weeks) for role in Roles if role.value.oncall) <= max_oncall_shifts_per_person
 
-        # [3.4] Not be on in-hours support in the same week that someone else from their team is also on in-hours support
-        # [3.5] Not be on in-hours support in the week after someone else from their team is also on in-hours support
+        # [2.5] Not be on in-hours support in the same week that someone else from their team is also on in-hours support
+        # [2.6] Not be on in-hours support in the week after someone else from their team is also on in-hours support
         for week in range(num_weeks):
             for person2, p2 in people.items():
                 if person == person2:
@@ -120,19 +100,11 @@ def generate_model(
 
     if optimise:
         # [1] Maximise the number of people with assignments
-        # [1] Minimise the maximum number of roles-assignments any one person has
-        # This is more important than the other optimisations (which are about reducing weeks which are bad in a fairly minor way) so give it a *1000 factor
+        # This is more important than the other optimisations (which are about reducing weeks which are bad in a fairly minor way) so give it a *100 factor
         obj = pulp.lpSum(assigned[person] for person in people.keys()) * 100
 
-        # [2] Maximise the number of weeks where secondary has been on in-hours support fewer than `times_inhours_for_primary` times
-        obj += pulp.lpSum(rota[week, person, Roles.SECONDARY.name] for week in range(num_weeks) for person, p in people.items() if p.num_times_inhours < times_inhours_for_primary)
-
-        # [3] Maximise the number of weeks where primary oncall has been on out-of-hours support fewer than `times_oncall_for_secondary` times
-        obj += pulp.lpSum(rota[week, person, Roles.PRIMARY_ONCALL.name] for week in range(num_weeks) for person, p in people.items() if p.num_times_oncall < times_oncall_for_secondary)
-
-        # [4] Maximise the number of weeks with a shadow
-        # or: Maximise the number of role assignments; which will have the same effect as the mandatory roles are always assigned
-        obj += pulp.lpSum(rota[week, person, role.name] for week in range(num_weeks) for person in people.keys() for role in Roles)
+        # [2] Maximise the number of weeks with a shadow
+        obj += pulp.lpSum(rota[week, person, Roles.SHADOW.name] for week in range(num_weeks) for person in people.keys())
 
         prob += obj
 

--- a/src/rota/govuk_2ndline.py
+++ b/src/rota/govuk_2ndline.py
@@ -33,23 +33,6 @@ class Govuk2ndLineRota(Rota):
     def is_assigned(self, week, person, role):
         return pulp.value(self.model[week, person, role.name]) == 1
 
-    def post_process(self, assignments):
-        """Implement constraints 2.1.3 and 2.5.3."""
-
-        # constraint [2.1.3]
-        primary = assignments["primary"]
-        secondary = assignments["secondary"]
-        if self.people[primary].num_times_inhours < self.people[secondary].num_times_inhours:
-            assignments["primary"] = secondary
-            assignments["secondary"] = primary
-
-        # constraint [2.5.3]
-        primary_oncall = assignments["primary_oncall"]
-        secondary_oncall = assignments["secondary_oncall"]
-        if self.people[secondary_oncall].num_times_oncall < self.people[primary_oncall].num_times_oncall:
-            assignments["primary_oncall"] = secondary_oncall
-            assignments["secondary_oncall"] = primary_oncall
-
 
 def generate_model(
     people,
@@ -62,17 +45,7 @@ def generate_model(
     max_times_shadow=3,
     optimise=True,
 ):
-    """Generate the mathematical model of the rota problem.
-
-    Constraints [1.2.3] (primary exp >= secondary exp) and [1.6.3]
-    (oncall secondary exp >= oncall primary exp) are not enforced
-    here, as they greatly slow down the solver (several seconds ->
-    several minutes and counting), and the other constraints are
-    sufficient to ensure qualified people are put in these roles.
-    Instead, the 'Rota.post_process' function, called by the
-    'printer.generate_rota_csv' function, swaps the people if need
-    be.
-    """
+    """Generate the mathematical model of the rota problem."""
 
     prob, rota, assigned = basic_rota(
         "2ndline rota",


### PR DESCRIPTION
It's kind of a pain keeping track of how many times someone has done inhours or oncall support, and so in practice we don't count above 3.  This works, because the eligibility rules only care whether someone has done something 3 times, but it means we're not taking advantage of rules like "the less experienced person should be primary oncall".

We also don't really make use of the ability for someone to, eg, have shadowed twice, and then in a single shift shadow once more and be secondary inhours in a later week.

So since we're not actually using any of the functionality which these counts power, let's just remove them.