### PR TITLE
Bump pulp from 2.4 to 2.5.1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,3 +27,9 @@ jobs:
       - name: Check Dependencies
         run: |
           pip install -r requirements-freeze.txt
+      - name: Build Demo Rota
+        run: |
+          set -ex
+          sudo apt-get update
+          sudo apt-get install -y coinor-cbc
+          python3 src demo.csv

--- a/requirements-freeze.txt
+++ b/requirements-freeze.txt
@@ -1,5 +1,5 @@
 amply==0.1.4
 docopt==0.6.2
 docutils==0.18.1
-PuLP==2.4
+PuLP==2.5.1
 pyparsing==2.4.7


### PR DESCRIPTION
For some reason the old PR didn't trigger an Actions run.